### PR TITLE
Send `x-client-id` in header

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,3 +2,5 @@
 VITE_THORNODE_URL=https://thornode.ninerealms.com
 # Midgard endpoint
 VITE_MIDGARD_URL=https://midgard.ninerealms.com
+# App identifier - needed for requests to ninerealms.com only - keep it empty if you are using other endpoints
+VITE_APP_IDENTIFIER=

--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 **LIVE** :eyes: https://veado.github.io/thorchain-proof-of-vaults
 
-
 https://user-images.githubusercontent.com/61792675/204032338-f6a515c6-df14-4887-b7af-d3ddd2d6dfa6.mp4
-
-
-
 
 ### Where does the data come from?
 
@@ -15,12 +11,15 @@ https://user-images.githubusercontent.com/61792675/204032338-f6a515c6-df14-4887-
 
 ## ENV
 
-Copy [env.sample](env.sample) and rename to `.env`. Change environment variables to you needs.
+Copy [env.sample](env.sample) and rename to `.env`. Change environment variables to your needs.
 
 ```
-# Midgard
-VITE_MIDGARD_URL=
-VITE_THORNODE_URL=
+# THORNode endpoint
+VITE_THORNODE_URL=https://thornode.ninerealms.com
+# Midgard endpoint
+VITE_MIDGARD_URL=https://midgard.ninerealms.com
+# App identifier - needed for requests to ninerealms.com only - keep it empty if you are using other endpoints
+VITE_APP_IDENTIFIER=
 ```
 
 ### Local development

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "thorchain-proof-of-vaults",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -6,6 +6,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+	readonly VITE_APP_IDENTIFIER: string;
 	readonly VITE_MIDGARD_URL: string;
 	readonly VITE_THORNODE_URL: string;
 	readonly VITE_VERSION: string;

--- a/src/stores/const.ts
+++ b/src/stores/const.ts
@@ -1,5 +1,7 @@
 import { ETHChain, type Asset } from '@xchainjs/xchain-util';
 
+export const APP_IDENTIFIER = import.meta.env?.VITE_APP_IDENTIFIER ?? '';
+
 export const THORNODE_DECIMAL = 8;
 export const THORNODE_URL = import.meta.env?.VITE_THORNODE_URL ?? 'https://thornode.ninerealms.com';
 export const MIDGARD_URL = import.meta.env?.VITE_MIDGARD_URL ?? 'https://midgard.ninerealms.com';

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -6,7 +6,7 @@ import {
 } from '@xchainjs/xchain-thornode';
 import type { Vault } from '@xchainjs/xchain-thornode';
 import * as FP from 'fp-ts/lib/function';
-import { MAX_REALOAD_COUNTER, THORNODE_URL } from './const';
+import { APP_IDENTIFIER, MAX_REALOAD_COUNTER, THORNODE_URL } from './const';
 import { derived, get, writable, type Readable, type Writable } from 'svelte/store';
 import * as E from 'fp-ts/lib/Either';
 import * as RD from '@devexperts/remote-data-ts';
@@ -36,6 +36,23 @@ import {
 } from '../utils/data';
 import type * as Ord from 'fp-ts/lib/Ord';
 import { assetToString, bnOrZero } from '@xchainjs/xchain-util';
+import type { AxiosRequestConfig } from 'axios';
+import axios from 'axios';
+
+const _options: AxiosRequestConfig = {
+	...axios.defaults,
+	headers: { ...(axios.defaults?.headers.common ?? {}), 'x-client-id': `${APP_IDENTIFIER}` }
+};
+
+// axios.interceptors.request.use(
+// 	(config) => {
+// 		config.headers['x-client-id'] = `${APP_IDENTIFIER}`;
+// 		return config;
+// 	},
+// 	(error) => {
+// 		return Promise.reject(error);
+// 	}
+// );
 
 const midgardConfig = new MidgardConfig({ basePath: MIDGARD_URL });
 const midgardApi = new DefaultApi(midgardConfig);
@@ -142,7 +159,7 @@ export const timeLeft$: Readable<number> = derived(
 
 const loadAsgards = (): TE.TaskEither<Error, Vault[]> =>
 	FP.pipe(
-		TE.tryCatch(() => vaultsApi.asgard(), E.toError),
+		TE.tryCatch(() => vaultsApi.asgard(undefined /* height */, options), E.toError),
 		TE.map(({ data }) => data)
 	);
 
@@ -154,7 +171,7 @@ const loadAsgardsJSON = (id: string): TE.TaskEither<Error, Vault[]> =>
 
 const loadYggs = (): TE.TaskEither<Error, Vault[]> =>
 	FP.pipe(
-		TE.tryCatch(() => vaultsApi.yggdrasil(), E.toError),
+		TE.tryCatch(() => vaultsApi.yggdrasil(undefined /* height */, options), E.toError),
 		TE.map(({ data }) => data)
 	);
 
@@ -166,7 +183,10 @@ const loadYggsJSON = (id: string): TE.TaskEither<Error, Vault[]> =>
 
 const loadPools = (): TE.TaskEither<Error, PoolDetails> =>
 	FP.pipe(
-		TE.tryCatch(() => midgardApi.getPools(), E.toError),
+		TE.tryCatch(
+			() => midgardApi.getPools(undefined /* status */, undefined /* period */, options),
+			E.toError
+		),
 		TE.map(({ data }) => data)
 	);
 
@@ -178,7 +198,7 @@ const loadPoolsJSON = (id: string): TE.TaskEither<Error, PoolDetails> =>
 
 const loadStats = (): TE.TaskEither<Error, StatsData> =>
 	FP.pipe(
-		TE.tryCatch(() => midgardApi.getStats(), E.toError),
+		TE.tryCatch(() => midgardApi.getStats(options), E.toError),
 		TE.map(({ data }) => data)
 	);
 
@@ -190,7 +210,7 @@ const loadStatsJSON = (id: string): TE.TaskEither<Error, StatsData> =>
 
 const loadNodes = (): TE.TaskEither<Error, Node[]> =>
 	FP.pipe(
-		TE.tryCatch(() => nodesApi.nodes(), E.toError),
+		TE.tryCatch(() => nodesApi.nodes(undefined /* height */, options), E.toError),
 		TE.map(({ data }) => data)
 	);
 

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -40,10 +40,19 @@ import axios from 'axios';
 
 axios.interceptors.request.use(
 	(config) => {
-		const url = new URL(config.url);
-		if (url.host.includes('ninerealms')) {
-			config.headers['x-client-id'] = `${APP_IDENTIFIER}`;
+		try {
+			// Creating an URL will throw an `TypeError` if `url` is not available and 'unknown-url' is set
+			// [TypeError: Invalid URL] input: 'unknown-url', code: 'ERR_INVALID_URL' }
+			const url = new URL(config?.url ?? 'unknown-url');
+			if (url.host.includes('ninerealms')) {
+				// headers can be undefined/empty in `AxiosRequestConfig`
+				if (!config.headers) config.headers = {};
+				config.headers['x-client-id'] = `${APP_IDENTIFIER}`;
+			}
+		} catch (error) {
+			console.error(`Failed to add custom 'x-client-id' header`, error);
 		}
+
 		return config;
 	},
 	(error) => {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -36,23 +36,20 @@ import {
 } from '../utils/data';
 import type * as Ord from 'fp-ts/lib/Ord';
 import { assetToString, bnOrZero } from '@xchainjs/xchain-util';
-import type { AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 
-const _options: AxiosRequestConfig = {
-	...axios.defaults,
-	headers: { ...(axios.defaults?.headers.common ?? {}), 'x-client-id': `${APP_IDENTIFIER}` }
-};
-
-// axios.interceptors.request.use(
-// 	(config) => {
-// 		config.headers['x-client-id'] = `${APP_IDENTIFIER}`;
-// 		return config;
-// 	},
-// 	(error) => {
-// 		return Promise.reject(error);
-// 	}
-// );
+axios.interceptors.request.use(
+	(config) => {
+		const url = new URL(config.url);
+		if (url.host.includes('ninerealms')) {
+			config.headers['x-client-id'] = `${APP_IDENTIFIER}`;
+		}
+		return config;
+	},
+	(error) => {
+		return Promise.reject(error);
+	}
+);
 
 const midgardConfig = new MidgardConfig({ basePath: MIDGARD_URL });
 const midgardApi = new DefaultApi(midgardConfig);
@@ -159,7 +156,7 @@ export const timeLeft$: Readable<number> = derived(
 
 const loadAsgards = (): TE.TaskEither<Error, Vault[]> =>
 	FP.pipe(
-		TE.tryCatch(() => vaultsApi.asgard(undefined /* height */, options), E.toError),
+		TE.tryCatch(() => vaultsApi.asgard(undefined /* height */), E.toError),
 		TE.map(({ data }) => data)
 	);
 
@@ -171,7 +168,7 @@ const loadAsgardsJSON = (id: string): TE.TaskEither<Error, Vault[]> =>
 
 const loadYggs = (): TE.TaskEither<Error, Vault[]> =>
 	FP.pipe(
-		TE.tryCatch(() => vaultsApi.yggdrasil(undefined /* height */, options), E.toError),
+		TE.tryCatch(() => vaultsApi.yggdrasil(undefined /* height */), E.toError),
 		TE.map(({ data }) => data)
 	);
 
@@ -184,7 +181,7 @@ const loadYggsJSON = (id: string): TE.TaskEither<Error, Vault[]> =>
 const loadPools = (): TE.TaskEither<Error, PoolDetails> =>
 	FP.pipe(
 		TE.tryCatch(
-			() => midgardApi.getPools(undefined /* status */, undefined /* period */, options),
+			() => midgardApi.getPools(undefined /* status */, undefined /* period */),
 			E.toError
 		),
 		TE.map(({ data }) => data)
@@ -198,7 +195,7 @@ const loadPoolsJSON = (id: string): TE.TaskEither<Error, PoolDetails> =>
 
 const loadStats = (): TE.TaskEither<Error, StatsData> =>
 	FP.pipe(
-		TE.tryCatch(() => midgardApi.getStats(options), E.toError),
+		TE.tryCatch(() => midgardApi.getStats(), E.toError),
 		TE.map(({ data }) => data)
 	);
 
@@ -210,7 +207,7 @@ const loadStatsJSON = (id: string): TE.TaskEither<Error, StatsData> =>
 
 const loadNodes = (): TE.TaskEither<Error, Node[]> =>
 	FP.pipe(
-		TE.tryCatch(() => nodesApi.nodes(undefined /* height */, options), E.toError),
+		TE.tryCatch(() => nodesApi.nodes(undefined /* height */), E.toError),
 		TE.map(({ data }) => data)
 	);
 


### PR DESCRIPTION
Needed for 9R endpoints.

Bump 0.9.2