### PR TITLE
Migration in progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "thorchain-proof-of-vaults",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,8 +10,11 @@
 		timeLeft$,
 		autoReload$$,
 		vaultSort$$,
-		vaultSearch$$
+		vaultSearch$$,
+		noRetiringAsgards$,
+		noActiveAsgards$
 	} from './stores/store';
+
 	import * as RD from '@devexperts/remote-data-ts';
 	import { onMount } from 'svelte';
 	import LoaderIcon from './components/LoaderIcon.svelte';
@@ -25,6 +28,7 @@
 	import * as FP from 'fp-ts/lib/function';
 	import Error from './components/Error.svelte';
 	import Footer from './components/Footer.svelte';
+	import MigrationStatus from './components/MigrationStatus.svelte';
 
 	$: loading = RD.isPending($dataRD$);
 	$: error = FP.pipe(
@@ -67,7 +71,7 @@
 	onMount(loadAllData);
 </script>
 
-<div class="flex flex-col px-5 md:px-10  xl:px-20">
+<div class="flex flex-col items-center px-5  md:px-10 xl:px-20">
 	<!-- logo + title -->
 	<header class="container flex flex-col items-center bg-gray-50 py-10">
 		<a href="https://thorchain.org/" class="">
@@ -117,6 +121,13 @@
 				</div>
 			</div>
 		</nav>
+		{#if $noRetiringAsgards$}
+			<MigrationStatus
+				noRetiringAsgards={$noRetiringAsgards$}
+				noActiveAsgards={$noActiveAsgards$}
+				class="w-full "
+			/>
+		{/if}
 
 		<!-- reload -->
 
@@ -124,7 +135,7 @@
 			<button
 				class="flex w-auto items-center rounded-full
            bg-gray-400 px-6 py-1 text-lg uppercase text-white
-            hover:bg-tc 
+            hover:bg-tc
          hover:shadow-lg {loading ? 'cursor-not-allowed' : 'cursor-pointer hover:scale-105'}
          ease
          "

--- a/src/components/MigrationStatus.svelte
+++ b/src/components/MigrationStatus.svelte
@@ -1,0 +1,22 @@
+<script>
+	import { ExclamationIcon } from '@krowten/svelte-heroicons';
+	import { plural } from '../utils/renderer';
+
+	let className = '';
+	export { className as class };
+
+	export let noActiveAsgards = 0;
+	export let noRetiringAsgards = 0;
+	const noTotaAsgards = noRetiringAsgards + noActiveAsgards;
+</script>
+
+<div class="flex items-center justify-center bg-yellow-500 px-2 text-white {className}">
+	<ExclamationIcon class="mr-1 h-6 w-6 sm:h-4 sm:w-4" />
+	<h2 class="text-center text-xs sm:text-sm">
+		Migration of {noTotaAsgards} <span class="uppercase">{plural('asgard', noTotaAsgards)}</span>
+		in progress
+		<span class="block sm:inline-block"
+			>({noRetiringAsgards} retiring / {noActiveAsgards} active)</span
+		>
+	</h2>
+</div>

--- a/src/components/Vaults.svelte
+++ b/src/components/Vaults.svelte
@@ -14,7 +14,7 @@
 		AssetRuneNative
 	} from '@xchainjs/xchain-util';
 
-	import { pools$, totalNoAsgard$, totalNoYggs$ } from '../stores/store';
+	import { pools$, noTotalAsgards$, noTotalYggs$ } from '../stores/store';
 	import { getNoVaultsFromVaultData, getPoolStatus } from '../utils/data';
 
 	import AssetIcon from './AssetIcon.svelte';
@@ -139,7 +139,7 @@
 					{noNodes} Nodes
 				</div>
 				<div class="text-center text-sm uppercase text-gray-400 lg:px-3">
-					to manage {$totalNoAsgard$} Asgards and {$totalNoYggs$} Yggdrasils
+					to manage {$noTotalAsgards$} Asgards and {$noTotalYggs$} Yggdrasils
 				</div>
 			{:else}
 				{@const poolStatus = getPoolStatus(asset, $pools$)}

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -59,12 +59,20 @@ export const vaults$: Readable<VaultList> = derived(dataRD$, (dataRD) =>
 	)
 );
 
-export const totalNoAsgard$: Readable<number> = derived(vaults$, (vaults) =>
-	getNoVaultsFromVaultList('asgard', vaults)
+export const noTotalAsgards$: Readable<number> = derived(vaults$, (vaults) =>
+	getNoVaultsFromVaultList({ type: 'asgard', list: vaults })
 );
 
-export const totalNoYggs$: Readable<number> = derived(vaults$, (vaults) =>
-	getNoVaultsFromVaultList('ygg', vaults)
+export const noActiveAsgards$: Readable<number> = derived(vaults$, (vaults) =>
+	getNoVaultsFromVaultList({ type: 'asgard', list: vaults, status: 'ActiveVault' })
+);
+
+export const noRetiringAsgards$: Readable<number> = derived(vaults$, (vaults) =>
+	getNoVaultsFromVaultList({ type: 'asgard', list: vaults, status: 'RetiringVault' })
+);
+
+export const noTotalYggs$: Readable<number> = derived(vaults$, (vaults) =>
+	getNoVaultsFromVaultList({ type: 'ygg', list: vaults })
 );
 
 const VAULT_SORT_MAP: Record<VaultSort, Ord.Ord<VaultListData>> = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -73,7 +73,6 @@ export type PoolsData = {
 	asset: Asset;
 	status: PoolStatus;
 	assetPriceUSD: BigNumber;
-	runeDepth: BigNumber;
 	decimal: number;
 };
 

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -130,7 +130,6 @@ export const toPoolsDataMap = (pools: PoolDetails): PoolsDataMap =>
 							asset,
 							status: (cur.status || 'unknown') as PoolStatus,
 							assetPriceUSD: bnOrZero(cur.assetPriceUSD),
-							runeDepth: bnOrZero(cur.runeDepth),
 							decimal
 						});
 					}
@@ -419,13 +418,21 @@ export const getEthTokenAddress = (asset: Asset): Address =>
 		ethGetAddr
 	);
 
-export const getNoVaultsFromVaultList = (type: VaultType, list: VaultList): number =>
+export const getNoVaultsFromVaultList = ({
+	type,
+	list,
+	status
+}: {
+	type: VaultType;
+	list: VaultList;
+	status?: VaultStatus;
+}): number =>
 	FP.pipe(
 		list,
 		A.map(({ data }) =>
 			FP.pipe(
 				data,
-				A.filter((d) => d.type === type)
+				A.filter((d) => d.type === type && (status ? d.status === status : true))
 			)
 		),
 		A.flatten,


### PR DESCRIPTION
![migration](https://user-images.githubusercontent.com/61792675/204288784-f1076852-976f-4450-ad4e-c3f0731bd37f.png)

- [x] Add optional `status` to `getNoVaultsFromVaultList`
- [x] `noActiveAsgards$` + `noRetiringAsgards$`
- [x] MigrationStatus component
- [x] Remove `runeDepth` from `PoolsData`
- [x] Quick fix layout (again)
- [x] Bump `0.9.1`